### PR TITLE
Add `useLayouts: false`

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -73,6 +73,7 @@ module.exports = (eleventyConfig, options) => {
   // Process CSS with LightningCSS
   eleventyConfig.addExtension("css", {
     outputFileExtension: "css",
+    useLayouts: false,
     compile: async function (_inputContent, inputPath) {
       let parsed = path.parse(inputPath);
       if (parsed.name.startsWith(importPrefix)) {


### PR DESCRIPTION
This PR adds `useLayouts: false` to the CSS template extension to prevent it from using layouts.

Use case: allows setting a global layout without applying it to .css files, e.g.:

```
eleventyConfig.addGlobalData('layout', 'base.html');
```